### PR TITLE
Patch addition: new terminal in current directory

### DIFF
--- a/config.h
+++ b/config.h
@@ -275,6 +275,7 @@ static Shortcut shortcuts[] = {
 	{ TERMMOD,              XK_J,           zoom,           {.f = -1} },
 	{ TERMMOD,              XK_U,           zoom,           {.f = +2} },
 	{ TERMMOD,              XK_D,           zoom,           {.f = -2} },
+	{ TERMMOD,              XK_Return,      newterm,        {.i =  0} },
 	{ MODKEY,               XK_l,           externalpipe,   {.v = openurlcmd } },
 	{ MODKEY,               XK_y,           externalpipe,   {.v = copyurlcmd } },
 	{ MODKEY,               XK_o,           externalpipe,   {.v = copyoutput } },

--- a/patches/st-desktopentry-0.8.2.diff
+++ b/patches/st-desktopentry-0.8.2.diff
@@ -1,0 +1,15 @@
+--- st-0.8.2-isotop/Makefile	Thu Mar 26 15:55:53 2020
++++ st-0.8.2/Makefile	Sat Feb  9 12:50:41 2019
+@@ -49,12 +49,9 @@ install: st
+ 	chmod 644 $(DESTDIR)$(MANPREFIX)/man1/st.1
+ 	tic -sx st.info
+ 	@echo Please see the README file regarding the terminfo entry of st.
+-	mkdir -p $(DESTDIR)$(PREFIX)/share/applications
+-	cp -f st.desktop $(DESTDIR)$(PREFIX)/share/applications
+ 
+ uninstall:
+ 	rm -f $(DESTDIR)$(PREFIX)/bin/st
+ 	rm -f $(DESTDIR)$(MANPREFIX)/man1/st.1
+-	rm -f $(DESTDIR)$(PREFIX)/share/applications/st.desktop
+ 
+ .PHONY: all options clean dist install uninstall

--- a/patches/st-newterm-0.8.2.diff
+++ b/patches/st-newterm-0.8.2.diff
@@ -1,0 +1,78 @@
+From a7eedc85e0609177cdb1ed3f6203fa37e6420012 Mon Sep 17 00:00:00 2001
+From: Matias Lang <yo@matiaslang.me>
+Date: Wed, 17 Jul 2019 01:10:44 -0300
+Subject: [PATCH] Add shortcut to spawn new terminal in the current dir
+
+Ctrl-Shift-Return now creates a new ST terminal, whose CWD is the same
+as the parent st's CWD
+---
+ config.def.h |  1 +
+ st.c         | 21 +++++++++++++++++++++
+ st.h         |  1 +
+ 3 files changed, 23 insertions(+)
+
+diff --git a/config.def.h b/config.def.h
+index 0e01717..31f26d8 100644
+--- a/config.def.h
++++ b/config.def.h
+@@ -178,6 +178,7 @@ static Shortcut shortcuts[] = {
+ 	{ TERMMOD,              XK_Y,           selpaste,       {.i =  0} },
+ 	{ ShiftMask,            XK_Insert,      selpaste,       {.i =  0} },
+ 	{ TERMMOD,              XK_Num_Lock,    numlock,        {.i =  0} },
++	{ TERMMOD,              XK_Return,      newterm,        {.i =  0} },
+ };
+
+ /*
+diff --git a/st.c b/st.c
+index b8e6077..044e29b 100644
+--- a/st.c
++++ b/st.c
+@@ -153,6 +153,7 @@ typedef struct {
+ } STREscape;
+
+ static void execsh(char *, char **);
++static char *getcwd_by_pid(pid_t pid);
+ static void stty(char **);
+ static void sigchld(int);
+ static void ttywriteraw(const char *, size_t);
+@@ -1059,6 +1060,26 @@ tswapscreen(void)
+ 	tfulldirt();
+ }
+
++void
++newterm(const Arg* a)
++{
++	switch (fork()) {
++	case -1:
++		die("fork failed: %s\n", strerror(errno));
++		break;
++	case 0:
++		chdir(getcwd_by_pid(pid));
++		execlp("st", "./st", NULL);
++		break;
++	}
++}
++
++static char *getcwd_by_pid(pid_t pid) {
++	char buf[32];
++	snprintf(buf, sizeof buf, "/proc/%d/cwd", pid);
++	return realpath(buf, NULL);
++}
++
+ void
+ tscrolldown(int orig, int n)
+ {
+diff --git a/st.h b/st.h
+index 38c61c4..54d4a43 100644
+--- a/st.h
++++ b/st.h
+@@ -80,6 +80,7 @@ void die(const char *, ...);
+ void redraw(void);
+ void draw(void);
+
++void newterm(const Arg *);
+ void printscreen(const Arg *);
+ void printsel(const Arg *);
+ void sendbreak(const Arg *);
+--
+2.19.2

--- a/patches/st-rightclickpaste-0.8.2.diff
+++ b/patches/st-rightclickpaste-0.8.2.diff
@@ -1,0 +1,28 @@
+From 111e5d0311f174592ccecee2af11067103abaee7 Mon Sep 17 00:00:00 2001
+From: aleks <aleks.stier@icloud.com>
+Date: Sun, 11 Aug 2019 03:15:26 +0200
+Subject: [PATCH] Make right-click paste
+
+Pressing right-click pastes from the primary-selection.
+If combined with the clipboard-patch right-click pastes from the clipboard.
+Middle-click does nothing.
+---
+ x.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/x.c b/x.c
+index 0422421..13a5849 100644
+--- a/x.c
++++ b/x.c
+@@ -643,7 +643,7 @@ brelease(XEvent *e)
+ 		return;
+ 	}
+ 
+-	if (e->xbutton.button == Button2)
++	if (e->xbutton.button == Button3)
+ 		selpaste(NULL);
+ 	else if (e->xbutton.button == Button1)
+ 		mousesel(e, 1);
+-- 
+2.22.0
+

--- a/st.c
+++ b/st.c
@@ -168,6 +168,7 @@ typedef struct {
 } STREscape;
 
 static void execsh(char *, char **);
+static char *getcwd_by_pid(pid_t pid);
 static void stty(char **);
 static void sigchld(int);
 static void ttywriteraw(const char *, size_t);
@@ -1077,6 +1078,26 @@ tswapscreen(void)
 	term.alt = tmp;
 	term.mode ^= MODE_ALTSCREEN;
 	tfulldirt();
+}
+
+void
+newterm(const Arg* a)
+{
+	switch (fork()) {
+	case -1:
+		die("fork failed: %s\n", strerror(errno));
+		break;
+	case 0:
+		chdir(getcwd_by_pid(pid));
+		execlp("st", "./st", NULL);
+		break;
+	}
+}
+
+static char *getcwd_by_pid(pid_t pid) {
+	char buf[32];
+	snprintf(buf, sizeof buf, "/proc/%d/cwd", pid);
+	return realpath(buf, NULL);
 }
 
 void

--- a/st.h
+++ b/st.h
@@ -92,6 +92,7 @@ void externalpipe(const Arg *);
 void iso14755(const Arg *);
 void kscrolldown(const Arg *);
 void kscrollup(const Arg *);
+void newterm(const Arg *);
 void printscreen(const Arg *);
 void printsel(const Arg *);
 void sendbreak(const Arg *);


### PR DESCRIPTION
This patch allows you to spawn a new st terminal using Ctrl-Shift-Return. It will have the same CWD (current working directory) as the original st instance.